### PR TITLE
SFENCE after streaming loops

### DIFF
--- a/src/x86_64/special/v2.rs
+++ b/src/x86_64/special/v2.rs
@@ -348,5 +348,10 @@ pub unsafe fn hash_chunk_of_16_intrin(
         hash_ptr = hash_ptr.add(1);
     }
 
+    // Required before returning to code that may set atomic flags that invite concurrent reads,
+    // as LLVM lowers `AtomicBool::store(flag, true, Release)` to ordinary stores on x86-64
+    // instead of SFENCE, even though SFENCE is required in the presence of nontemporal stores.
+    _mm_sfence();
+
     return (pixel_ptr as *const u32, hash_ptr as *mut u8);
 }

--- a/src/x86_64/special/v3n.rs
+++ b/src/x86_64/special/v3n.rs
@@ -62,6 +62,7 @@ pub unsafe fn hash_chunk_of_32_avx_vnni(
     "cmp        {pixels_ptr},   {pixels_end_ptr}",
     //"# LLVM-MCA-END 32nn",
     "jne 2b",
+    "sfence", // Guard the vmovntdq after the loop
 
     multiplier  = in(reg)   &HASH_MULTIPLIER_RGBA,
     byte_mask   = in(reg)   &0x3f,


### PR DESCRIPTION
MOVNTI, MOVNTDQ, and friends weaken TSO when next to other stores. As most stores are not nontemporal, LLVM uses simple stores when lowering LLVMIR like `atomic store ... release` on x86, itself a lowering of Rust's `AtomicBool::store(.., .., Ordering::Release)`. These facts could allow something like the following code to be emitted:

```asm
vmovntdq [addr],     ymmreg
vmovntdq [addr+32],  ymmreg
vmovntdq [addr+64],  ymmreg
vmovntdq [addr+96],  ymmreg
mov byte ptr [flag], 1 ; producer-consumer flag
```

But these stores are NOT ordered with respect to each other! Nontemporal stores induce the CPU to use write-combining buffers. These writes will be resolved in bursts instead of at once, and the write may be further deferred until a serialization point. Even a "yes-temporal" write to any other location will not force the deferred writes to be resolved first. Thus, assuming cache-line-sized buffers of 64 bytes, the CPU may resolve these writes in e.g. this actual order:

```asm
vmovntdq [addr+64],  ymmreg
vmovntdq [addr+96],  ymmreg
mov byte ptr [flag], 1
vmovntdq [addr+32],  ymmreg
vmovntdq [addr],     ymmreg
```

This could e.g. result in other threads accessing this address after the flag is set, thus accessing memory via safe code that was assumed to be correctly synchronized. This could result in observing tearing or other inconsistent program states, especially as the number of writes, thus the number of write buffers that may begin retiring simultaneously, thus the chance of them resolving in an unfortunate order, increases.

To guarantee program soundness, code using nontemporal stores must currently use SFENCE in its safety boundary, unless and until LLVM decides this combination of facts should be considered a miscompilation and motivation to choose lowerings that do not require explicit SFENCE. Even `unsafe fn` must explicitly pass this invariant to their callers!

To prevent unsoundness, SFENCE after the loop of nontemporal stores.